### PR TITLE
Make action_chain module pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub mod prelude {
     pub use thirtyfour::{By, Cookie, DesiredCapabilities, Keys, ScriptArgs, TypingData};
 }
 
-mod action_chain;
+pub mod action_chain;
 mod alert;
 pub mod http {
     pub mod connection_sync;


### PR DESCRIPTION
This is pub in `thirtyfour` and it contains the type `ActionChain`
which is returned from a public method.  Making it private seems to
have been an oversight.

Signed-off-by: Ian Jackson <ijackson@chiark.greenend.org.uk>